### PR TITLE
fix: upgrade go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/access
 
-go 1.23.2
+go 1.23.5
 
 require (
 	github.com/casbin/casbin/v2 v2.102.0


### PR DESCRIPTION
closes https://github.com/cccteam/access/issues/59