### PR TITLE
feat: bump Go version to 1.24.6 due to vuln

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/access
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/casbin/casbin/v2 v2.108.0


### PR DESCRIPTION
Closes https://github.com/cccteam/access/issues/97