### PR TITLE
feat: upgrade Go patch version to address vulns

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cccteam/access
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/casbin/casbin/v2 v2.135.0


### PR DESCRIPTION
Closes #158 - see this security scan [test run](https://github.com/cccteam/access/actions/runs/24350908471/job/71104727643) for evidence.