### PR TITLE
refactor: introduce engine seam behind access checks and user management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,6 @@ jobs:
     uses: cccteam/github-workflows/.github/workflows/golang-ci.yml@7f103553e4cb3524d127299a6ac70d85156d36b3 # v7.0.0
     with:
       build-tags: '[""]'
-      golangci-lint-version: "v2.11.2"
+      golangci-lint-version: "v2.12.2"
   semantic-titles:
     uses: cccteam/github-workflows/.github/workflows/semantic-pull-request-title.yml@7f103553e4cb3524d127299a6ac70d85156d36b3 # v7.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,6 @@ linters:
     - govet
     - importas
     - ineffassign
-    - lll
     - makezero
     - misspell
     - nakedret
@@ -96,8 +95,6 @@ linters:
       keywords:
         - TODO
         - BUG
-    lll:
-      line-length: 200
     misspell:
       locale: US
     nestif:
@@ -131,7 +128,6 @@ linters:
           - gochecknoinits
           - goconst
           - gocyclo
-          - lll
           - mnd
           - nlreturn
           - scopelint

--- a/access.go
+++ b/access.go
@@ -14,18 +14,20 @@ var _ Controller = &Client{}
 
 // Client is the main access control client for permission checking and user management.
 type Client struct {
+	evaluator   evaluator
 	userManager *userManager
 }
 
-// New creates a new Client with specified domains and adapter. Errors if user manager initialization fails.
+// New creates a new Client with specified domains and adapter. Errors if engine initialization fails.
 func New(domains Domains, adapter Adapter) (*Client, error) {
-	userManager, err := newUserManager(domains, adapter)
+	engine, err := newCasbinEngine(adapter)
 	if err != nil {
-		return nil, errors.Wrap(err, "newUserManager()")
+		return nil, errors.Wrap(err, "newCasbinEngine()")
 	}
 
 	return &Client{
-		userManager: userManager,
+		evaluator:   engine,
+		userManager: newUserManager(domains, engine),
 	}, nil
 }
 
@@ -46,11 +48,11 @@ func (c *Client) RequireAll(ctx context.Context, username accesstypes.User, doma
 	}
 
 	for _, perm := range perms {
-		authorized, err := c.userManager.Enforcer().Enforce(username.Marshal(), domain.Marshal(), accesstypes.GlobalResource.Marshal(), perm.Marshal())
+		missing, err := c.evaluator.checkUser(ctx, username, domain, perm, accesstypes.GlobalResource)
 		if err != nil {
-			return errors.Wrap(err, "casbin.IEnforcer Enforce()")
+			return err
 		}
-		if !authorized {
+		if len(missing) > 0 {
 			return httpio.NewForbiddenMessagef("user %s does not have %s", username, perm)
 		}
 	}
@@ -66,7 +68,22 @@ func (c *Client) RequireResources(
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
-	return c.requireResources(ctx, username.Marshal(), domain, perm, resources...)
+	if exists, err := c.userManager.DomainExists(ctx, domain); err != nil {
+		return false, nil, err
+	} else if !exists {
+		return false, nil, httpio.NewBadRequestMessage("Invalid Domain")
+	}
+
+	missing, err := c.evaluator.checkUser(ctx, username, domain, perm, resources...)
+	if err != nil {
+		return false, nil, err
+	}
+
+	if len(missing) > 0 {
+		return false, missing, nil
+	}
+
+	return true, nil, nil
 }
 
 // RoleRequireResources checks if role has permission for resources in domain.
@@ -77,35 +94,15 @@ func (c *Client) RoleRequireResources(
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
-	return c.requireResources(ctx, role.Marshal(), domain, perm, resources...)
-}
-
-// UserManager returns the UserManager for managing users, roles, and permissions.
-func (c *Client) UserManager() UserManager {
-	return c.userManager
-}
-
-func (c *Client) requireResources(
-	ctx context.Context, subject string, domain accesstypes.Domain, perm accesstypes.Permission, resources ...accesstypes.Resource,
-) (bool, []accesstypes.Resource, error) {
-	ctx, span := tracer.Start(ctx)
-	defer span.End()
-
 	if exists, err := c.userManager.DomainExists(ctx, domain); err != nil {
 		return false, nil, err
 	} else if !exists {
 		return false, nil, httpio.NewBadRequestMessage("Invalid Domain")
 	}
 
-	missing := make([]accesstypes.Resource, 0)
-	for _, resource := range resources {
-		authorized, err := c.userManager.Enforcer().Enforce(subject, domain.Marshal(), resource.Marshal(), perm.Marshal())
-		if err != nil {
-			return false, nil, errors.Wrap(err, "casbin.IEnforcer Enforce()")
-		}
-		if !authorized {
-			missing = append(missing, resource)
-		}
+	missing, err := c.evaluator.checkRole(ctx, role, domain, perm, resources...)
+	if err != nil {
+		return false, nil, err
 	}
 
 	if len(missing) > 0 {
@@ -113,4 +110,9 @@ func (c *Client) requireResources(
 	}
 
 	return true, nil, nil
+}
+
+// UserManager returns the UserManager for managing users, roles, and permissions.
+func (c *Client) UserManager() UserManager {
+	return c.userManager
 }

--- a/enforcer.go
+++ b/enforcer.go
@@ -1,10 +1,15 @@
 package access
 
 import (
+	"context"
+	"slices"
+	"sort"
+	"sync"
 	"time"
 
 	"github.com/casbin/casbin/v2"
 	"github.com/casbin/casbin/v2/model"
+	"github.com/cccteam/ccc/accesstypes"
 	"github.com/go-playground/errors/v5"
 )
 
@@ -24,68 +29,322 @@ func createEnforcer(rbacModel string) (*casbin.SyncedEnforcer, error) {
 	return e, nil
 }
 
-func (u *userManager) refreshEnforcer() casbin.IEnforcer {
-	u.initEnforcer()
+var (
+	_ evaluator   = &casbinEngine{}
+	_ policyStore = &casbinEngine{}
+)
 
-	return u.loadPolicy()
+// casbinEngine implements the evaluator and policyStore seams on the casbin path.
+// All casbin-specific concerns live here: the enforcer lifecycle, the
+// user:/role:/resource:/perm: Marshal prefixes, and the noop sentinel user that
+// makes empty roles enumerable.
+type casbinEngine struct {
+	Enforcer func() casbin.IEnforcer // Exposed for testing
+
+	adapter Adapter
+
+	policyMu     sync.RWMutex
+	policyLoaded bool
+
+	enforcerMu          sync.RWMutex
+	enforcer            casbin.IEnforcer
+	enforcerInitialized bool
 }
 
-func (u *userManager) initEnforcer() {
-	u.enforcerMu.RLock()
-	if u.enforcerInitialized {
-		u.enforcerMu.RUnlock()
+// newCasbinEngine creates the casbin-backed engine. Errors if enforcer creation fails.
+func newCasbinEngine(adapter Adapter) (*casbinEngine, error) {
+	enforcer, err := createEnforcer(rbacModel())
+	if err != nil {
+		return nil, err
+	}
+
+	e := &casbinEngine{
+		adapter:  adapter,
+		enforcer: enforcer,
+	}
+	e.Enforcer = e.refreshEnforcer
+
+	return e, nil
+}
+
+func (c *casbinEngine) refreshEnforcer() casbin.IEnforcer {
+	c.initEnforcer()
+
+	return c.loadPolicy()
+}
+
+func (c *casbinEngine) initEnforcer() {
+	c.enforcerMu.RLock()
+	if c.enforcerInitialized {
+		c.enforcerMu.RUnlock()
 
 		return
 	}
-	u.enforcerMu.RUnlock()
+	c.enforcerMu.RUnlock()
 
-	u.enforcerMu.Lock()
-	defer u.enforcerMu.Unlock()
+	c.enforcerMu.Lock()
+	defer c.enforcerMu.Unlock()
 
-	if u.enforcerInitialized {
+	if c.enforcerInitialized {
 		// lost race for lock
 		return
 	}
 	// won race for lock
 
-	a, err := u.adapter.NewAdapter()
+	a, err := c.adapter.NewAdapter()
 	if err != nil {
 		panic(errors.Wrapf(err, "pgxadapter.NewAdapter(): failed to create casbin adapter with db"))
 	}
 
-	u.enforcer.SetAdapter(a)
+	c.enforcer.SetAdapter(a)
 
-	u.enforcerInitialized = true
+	c.enforcerInitialized = true
 }
 
-func (u *userManager) loadPolicy() casbin.IEnforcer {
-	u.policyMu.RLock()
-	if u.policyLoaded {
-		defer u.policyMu.RUnlock()
+func (c *casbinEngine) loadPolicy() casbin.IEnforcer {
+	c.policyMu.RLock()
+	if c.policyLoaded {
+		defer c.policyMu.RUnlock()
 
-		return u.enforcer
+		return c.enforcer
 	}
-	u.policyMu.RUnlock()
+	c.policyMu.RUnlock()
 
-	u.policyMu.Lock()
-	defer u.policyMu.Unlock()
+	c.policyMu.Lock()
+	defer c.policyMu.Unlock()
 
-	if u.policyLoaded {
-		return u.enforcer
+	if c.policyLoaded {
+		return c.enforcer
 	}
 
-	if err := u.enforcer.LoadPolicy(); err != nil {
+	if err := c.enforcer.LoadPolicy(); err != nil {
 		panic(errors.Wrapf(err, "casbin.SyncedEnforcer.LoadPolicy()"))
 	}
 
-	u.policyLoaded = true
+	c.policyLoaded = true
 
 	go func() {
 		time.Sleep(time.Minute)
-		u.policyMu.Lock()
-		u.policyLoaded = false
-		u.policyMu.Unlock()
+		c.policyMu.Lock()
+		c.policyLoaded = false
+		c.policyMu.Unlock()
 	}()
 
-	return u.enforcer
+	return c.enforcer
+}
+
+func (c *casbinEngine) checkUser(ctx context.Context, user accesstypes.User, domain accesstypes.Domain, perm accesstypes.Permission, resources ...accesstypes.Resource) ([]accesstypes.Resource, error) {
+	return c.check(ctx, user.Marshal(), domain, perm, resources...)
+}
+
+func (c *casbinEngine) checkRole(ctx context.Context, role accesstypes.Role, domain accesstypes.Domain, perm accesstypes.Permission, resources ...accesstypes.Resource) ([]accesstypes.Resource, error) {
+	return c.check(ctx, role.Marshal(), domain, perm, resources...)
+}
+
+func (c *casbinEngine) check(_ context.Context, subject string, domain accesstypes.Domain, perm accesstypes.Permission, resources ...accesstypes.Resource) ([]accesstypes.Resource, error) {
+	missing := make([]accesstypes.Resource, 0)
+	for _, resource := range resources {
+		authorized, err := c.Enforcer().Enforce(subject, domain.Marshal(), resource.Marshal(), perm.Marshal())
+		if err != nil {
+			return nil, errors.Wrap(err, "casbin.IEnforcer Enforce()")
+		}
+		if !authorized {
+			missing = append(missing, resource)
+		}
+	}
+
+	return missing, nil
+}
+
+func (c *casbinEngine) addUserRole(_ context.Context, domain accesstypes.Domain, user accesstypes.User, role accesstypes.Role) error {
+	if _, err := c.Enforcer().AddRoleForUser(user.Marshal(), role.Marshal(), domain.Marshal()); err != nil {
+		return errors.Wrapf(err, "casbin.SyncedEnforcer.AddRoleForUser(): role %q to %q", role.Marshal(), user)
+	}
+
+	return nil
+}
+
+func (c *casbinEngine) deleteUserRole(_ context.Context, domain accesstypes.Domain, user accesstypes.User, role accesstypes.Role) error {
+	if _, err := c.Enforcer().DeleteRoleForUser(user.Marshal(), role.Marshal(), domain.Marshal()); err != nil {
+		return errors.Wrapf(err, "casbin.SyncedEnforcer.DeleteRoleForUser(): role %q to %q", role.Marshal(), user)
+	}
+
+	return nil
+}
+
+func (c *casbinEngine) users(_ context.Context) ([]accesstypes.User, error) {
+	var users []accesstypes.User
+	userMap := make(map[string]bool)
+	roles, err := c.Enforcer().GetAllRoles()
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetAllRoles()")
+	}
+
+	subjects, err := c.Enforcer().GetAllSubjects()
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetAllSubjects()")
+	}
+SUB:
+	// loop through the subjects (containing both roles and usernames)
+	// and if it is a a role, skip it, otherwise add user to the map
+	for _, user := range subjects {
+		for _, role := range roles {
+			if role == user || user == accesstypes.NoopUser {
+				continue SUB
+			}
+		}
+
+		users = append(users, accesstypes.UnmarshalUser(user))
+		userMap[user] = true
+	}
+	// now get the grouping policy and look for users in there
+	groupingPolicy, err := c.Enforcer().GetGroupingPolicy()
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetGroupingPolicy()")
+	}
+GP:
+	for _, gp := range groupingPolicy {
+		user := gp[0]
+		if userMap[user] || user == accesstypes.NoopUser {
+			continue
+		}
+
+		for _, role := range roles {
+			if role == user {
+				continue GP
+			}
+		}
+
+		users = append(users, accesstypes.UnmarshalUser(user))
+		userMap[user] = true
+	}
+
+	return users, nil
+}
+
+func (c *casbinEngine) userRoles(_ context.Context, domain accesstypes.Domain, user accesstypes.User) ([]accesstypes.Role, error) {
+	strRoles, err := c.Enforcer().GetRolesForUser(user.Marshal(), domain.Marshal())
+	if err != nil {
+		return nil, errors.Wrapf(err, "casbin.SyncedEnforcer.GetRolesForUser(): user: %q", user)
+	}
+
+	roles := make([]accesstypes.Role, 0, len(strRoles))
+	for _, role := range strRoles {
+		roles = append(roles, accesstypes.UnmarshalRole(role))
+	}
+
+	return roles, nil
+}
+
+func (c *casbinEngine) userPermissions(_ context.Context, domain accesstypes.Domain, user accesstypes.User) (map[accesstypes.Resource][]accesstypes.Permission, error) {
+	strPerms, err := c.Enforcer().GetImplicitPermissionsForUser(user.Marshal(), domain.Marshal())
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetImplicitPermissionsForUser()")
+	}
+
+	permissions := make(map[accesstypes.Resource][]accesstypes.Permission)
+	for _, perm := range strPerms {
+		if slices.Contains(permissions[accesstypes.UnmarshalResource(perm[2])], accesstypes.UnmarshalPermission(perm[3])) {
+			continue
+		}
+		permissions[accesstypes.UnmarshalResource(perm[2])] = append(permissions[accesstypes.UnmarshalResource(perm[2])], accesstypes.UnmarshalPermission(perm[3]))
+	}
+
+	return permissions, nil
+}
+
+func (c *casbinEngine) addRole(_ context.Context, domain accesstypes.Domain, role accesstypes.Role) error {
+	if _, err := c.Enforcer().AddGroupingPolicy(accesstypes.NoopUser, role.Marshal(), domain.Marshal()); err != nil {
+		return errors.Wrap(err, "enforcer.AddGroupingPolicy()")
+	}
+
+	return nil
+}
+
+func (c *casbinEngine) roles(_ context.Context, domain accesstypes.Domain) ([]accesstypes.Role, error) {
+	// filter by domain
+	grouping, err := c.Enforcer().GetFilteredGroupingPolicy(2, domain.Marshal())
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetFilteredGroupingPolicy()")
+	}
+
+	roleMap := map[accesstypes.Role]bool{}
+	for _, group := range grouping {
+		roleMap[accesstypes.UnmarshalRole(group[1])] = true
+	}
+
+	roles := make([]accesstypes.Role, 0, len(roleMap))
+
+	for role := range roleMap {
+		roles = append(roles, role)
+	}
+
+	// ensures the list is always returned in the same order as casbin doesn't handle this
+	sort.Slice(roles, func(i int, j int) bool {
+		return string(roles[i]) < string(roles[j])
+	})
+
+	return roles, nil
+}
+
+func (c *casbinEngine) deleteRole(_ context.Context, role accesstypes.Role) (bool, error) {
+	deleted, err := c.Enforcer().DeleteRole(role.Marshal())
+	if err != nil {
+		return false, errors.Wrap(err, "enforcer.DeleteRole()")
+	}
+
+	return deleted, nil
+}
+
+func (c *casbinEngine) roleExists(_ context.Context, domain accesstypes.Domain, role accesstypes.Role) bool {
+	roles := c.Enforcer().GetRolesForUserInDomain(accesstypes.NoopUser, domain.Marshal())
+
+	return slices.Contains(roles, role.Marshal())
+}
+
+func (c *casbinEngine) roleUsers(_ context.Context, domain accesstypes.Domain, role accesstypes.Role) ([]accesstypes.User, error) {
+	users, err := c.Enforcer().GetUsersForRole(role.Marshal(), domain.Marshal())
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetUsersForRole()")
+	}
+
+	actualUsers := make([]accesstypes.User, 0, len(users))
+	for _, user := range users {
+		if user == accesstypes.NoopUser {
+			continue
+		}
+		actualUsers = append(actualUsers, accesstypes.UnmarshalUser(user))
+	}
+
+	return actualUsers, nil
+}
+
+func (c *casbinEngine) addGrant(_ context.Context, domain accesstypes.Domain, role accesstypes.Role, perm accesstypes.Permission, resource accesstypes.Resource) error {
+	if _, err := c.Enforcer().AddPolicy(role.Marshal(), domain.Marshal(), resource.Marshal(), perm.Marshal(), "allow"); err != nil {
+		return errors.Wrap(err, "enforcer.AddPolicy()")
+	}
+
+	return nil
+}
+
+func (c *casbinEngine) removeGrant(_ context.Context, domain accesstypes.Domain, role accesstypes.Role, perm accesstypes.Permission, resource accesstypes.Resource) error {
+	if _, err := c.Enforcer().RemoveFilteredPolicy(0, role.Marshal(), domain.Marshal(), resource.Marshal(), perm.Marshal()); err != nil {
+		return errors.Wrapf(err, "enforcer.RemoveFilteredPolicy() role=%q, domain=%q", role, domain)
+	}
+
+	return nil
+}
+
+func (c *casbinEngine) roleGrants(_ context.Context, domain accesstypes.Domain, role accesstypes.Role) (accesstypes.RolePermissionCollection, error) {
+	policies, err := c.Enforcer().GetFilteredPolicy(0, role.Marshal(), domain.Marshal())
+	if err != nil {
+		return nil, errors.Wrap(err, "enforcer.GetFilteredPolicy()")
+	}
+
+	permissions := make(accesstypes.RolePermissionCollection, len(policies))
+	for _, p := range policies {
+		permissions[accesstypes.UnmarshalPermission(p[3])] = append(permissions[accesstypes.UnmarshalPermission(p[3])], accesstypes.UnmarshalResource(p[2]))
+	}
+
+	return permissions, nil
 }

--- a/engine.go
+++ b/engine.go
@@ -1,0 +1,50 @@
+package access
+
+import (
+	"context"
+
+	"github.com/cccteam/ccc/accesstypes"
+)
+
+// evaluator answers permission checks on the request path. It is the seam the
+// snapshot engine will implement; the casbin path is the first implementation.
+// Implementations must be safe for concurrent use.
+type evaluator interface {
+	// checkUser returns the subset of resources that user does NOT hold perm on
+	// within domain. An empty result means all resources passed.
+	checkUser(
+		ctx context.Context, user accesstypes.User, domain accesstypes.Domain, perm accesstypes.Permission, resources ...accesstypes.Resource,
+	) (missing []accesstypes.Resource, err error)
+
+	// checkRole returns the subset of resources that role does NOT hold perm on
+	// within domain. An empty result means all resources passed.
+	checkRole(
+		ctx context.Context, role accesstypes.Role, domain accesstypes.Domain, perm accesstypes.Permission, resources ...accesstypes.Resource,
+	) (missing []accesstypes.Resource, err error)
+}
+
+// policyStore is the management surface for role membership, role existence, and
+// grants. Validation (domain/role existence, empty-input checks) belongs to the
+// callers; implementations only persist and query policy.
+type policyStore interface {
+	// Membership
+	addUserRole(ctx context.Context, domain accesstypes.Domain, user accesstypes.User, role accesstypes.Role) error
+	deleteUserRole(ctx context.Context, domain accesstypes.Domain, user accesstypes.User, role accesstypes.Role) error
+	users(ctx context.Context) ([]accesstypes.User, error)
+	userRoles(ctx context.Context, domain accesstypes.Domain, user accesstypes.User) ([]accesstypes.Role, error)
+	userPermissions(ctx context.Context, domain accesstypes.Domain, user accesstypes.User) (map[accesstypes.Resource][]accesstypes.Permission, error)
+
+	// Roles
+	addRole(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) error
+	roles(ctx context.Context, domain accesstypes.Domain) ([]accesstypes.Role, error)
+	// deleteRole removes the role and its grants across ALL domains, not just the
+	// one it was addressed in (casbin legacy behavior, preserved through the swap).
+	deleteRole(ctx context.Context, role accesstypes.Role) (bool, error)
+	roleExists(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) bool
+	roleUsers(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) ([]accesstypes.User, error)
+
+	// Grants
+	addGrant(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role, perm accesstypes.Permission, resource accesstypes.Resource) error
+	removeGrant(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role, perm accesstypes.Permission, resource accesstypes.Resource) error
+	roleGrants(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) (accesstypes.RolePermissionCollection, error)
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -1,0 +1,168 @@
+package access
+
+import (
+	"context"
+	"testing"
+
+	"github.com/casbin/casbin/v2"
+	"github.com/cccteam/ccc/accesstypes"
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_casbinEngine_checkUser(t *testing.T) {
+	t.Parallel()
+
+	enforcer, err := mockEnforcer("testdata/policy_users.csv")
+	if err != nil {
+		t.Fatalf("failed to load policies. err=%s", err)
+	}
+	e := &casbinEngine{
+		Enforcer: func() casbin.IEnforcer {
+			return enforcer
+		},
+	}
+
+	type args struct {
+		user      accesstypes.User
+		domain    accesstypes.Domain
+		perm      accesstypes.Permission
+		resources []accesstypes.Resource
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantMissing []accesstypes.Resource
+	}{
+		{
+			name: "user with permission through role",
+			args: args{
+				user:      "charlie",
+				domain:    "tenant1",
+				perm:      "DeleteUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{},
+		},
+		{
+			name: "user with direct permission",
+			args: args{
+				user:      "alice",
+				domain:    "tenant2",
+				perm:      "ViewUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{},
+		},
+		{
+			name: "user without permission in domain",
+			args: args{
+				user:      "alice",
+				domain:    "tenant1",
+				perm:      "ViewUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{accesstypes.GlobalResource},
+		},
+		{
+			name: "role grant does not apply in another domain",
+			args: args{
+				user:      "bob",
+				domain:    "tenant2",
+				perm:      "ViewUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{accesstypes.GlobalResource},
+		},
+		{
+			name: "partially missing resources",
+			args: args{
+				user:      "charlie",
+				domain:    "tenant1",
+				perm:      "DeleteUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource, "Widgets"},
+			},
+			wantMissing: []accesstypes.Resource{"Widgets"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotMissing, err := e.checkUser(context.Background(), tt.args.user, tt.args.domain, tt.args.perm, tt.args.resources...)
+			if err != nil {
+				t.Fatalf("casbinEngine.checkUser() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.wantMissing, gotMissing); diff != "" {
+				t.Errorf("casbinEngine.checkUser() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_casbinEngine_checkRole(t *testing.T) {
+	t.Parallel()
+
+	enforcer, err := mockEnforcer("testdata/policy_users.csv")
+	if err != nil {
+		t.Fatalf("failed to load policies. err=%s", err)
+	}
+	e := &casbinEngine{
+		Enforcer: func() casbin.IEnforcer {
+			return enforcer
+		},
+	}
+
+	type args struct {
+		role      accesstypes.Role
+		domain    accesstypes.Domain
+		perm      accesstypes.Permission
+		resources []accesstypes.Resource
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantMissing []accesstypes.Resource
+	}{
+		{
+			name: "role with permission",
+			args: args{
+				role:      "Administrator",
+				domain:    "tenant1",
+				perm:      "DeleteUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{},
+		},
+		{
+			name: "role without permission",
+			args: args{
+				role:      "Editor",
+				domain:    "tenant1",
+				perm:      "DeleteUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{accesstypes.GlobalResource},
+		},
+		{
+			name: "role grant scoped to its domain",
+			args: args{
+				role:      "Editor",
+				domain:    "tenant2",
+				perm:      "ViewUsers",
+				resources: []accesstypes.Resource{accesstypes.GlobalResource},
+			},
+			wantMissing: []accesstypes.Resource{accesstypes.GlobalResource},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotMissing, err := e.checkRole(context.Background(), tt.args.role, tt.args.domain, tt.args.perm, tt.args.resources...)
+			if err != nil {
+				t.Fatalf("casbinEngine.checkRole() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.wantMissing, gotMissing); diff != "" {
+				t.Errorf("casbinEngine.checkRole() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/migrate.go
+++ b/migrate.go
@@ -18,6 +18,9 @@ type PermissionCollection interface {
 	IsResourceImmutable(scope accesstypes.PermissionScope, res accesstypes.Resource) bool
 }
 
+// administratorRole is the default role granted all permissions by MigrateRoles.
+const administratorRole accesstypes.Role = "Administrator"
+
 // RoleConfig contains roles for migration.
 type RoleConfig struct {
 	Roles []*Role `json:"roles"`
@@ -37,7 +40,7 @@ func MigrateRoles(ctx context.Context, client UserManager, store PermissionColle
 
 	// Default Administrator role has all permissions
 	roleConfig.Roles = append(roleConfig.Roles, &Role{
-		Name:        "Administrator",
+		Name:        administratorRole,
 		Permissions: adminPermissions(store),
 	})
 

--- a/usermanagement.go
+++ b/usermanagement.go
@@ -5,9 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
-	"sync"
 
-	"github.com/casbin/casbin/v2"
 	"github.com/cccteam/ccc/accesstypes"
 	"github.com/cccteam/ccc/tracer"
 	"github.com/cccteam/httpio"
@@ -16,36 +14,20 @@ import (
 
 var _ UserManager = &userManager{}
 
-// userManager implements UserManager with casbin enforcement and thread-safe operations.
+// userManager implements UserManager on top of the policyStore seam.
+// Validation (domain/role existence, empty-input checks) lives here; the store
+// only persists and queries policy.
 type userManager struct {
-	Enforcer func() casbin.IEnforcer // Exposed for testing
-	domains  Domains
-	adapter  Adapter
-
-	policyMu     sync.RWMutex
-	policyLoaded bool
-
-	enforcerMu          sync.RWMutex
-	enforcer            casbin.IEnforcer
-	enforcerInitialized bool
+	store   policyStore
+	domains Domains
 }
 
-// newUserManager creates userManager. Errors if casbin enforcer creation fails.
-func newUserManager(domains Domains, adapter Adapter) (*userManager, error) {
-	enforcer, err := createEnforcer(rbacModel())
-	if err != nil {
-		return nil, err
+// newUserManager creates userManager backed by the given policy store.
+func newUserManager(domains Domains, store policyStore) *userManager {
+	return &userManager{
+		store:   store,
+		domains: domains,
 	}
-
-	u := &userManager{
-		adapter:  adapter,
-		enforcer: enforcer,
-		domains:  domains,
-	}
-
-	u.Enforcer = u.refreshEnforcer
-
-	return u, nil
 }
 
 // AddRoleUsers assigns a specified role to multiple users within a domain.
@@ -64,8 +46,8 @@ func (u *userManager) AddRoleUsers(ctx context.Context, domain accesstypes.Domai
 			return httpio.NewBadRequestMessage("user cannot be empty string")
 		}
 
-		if _, err := u.Enforcer().AddRoleForUser(user.Marshal(), role.Marshal(), domain.Marshal()); err != nil {
-			return errors.Wrapf(err, "casbin.SyncedEnforcer.AddRoleForUser(): role %q to %q", role.Marshal(), user)
+		if err := u.store.addUserRole(ctx, domain, user, role); err != nil {
+			return err
 		}
 	}
 
@@ -89,8 +71,8 @@ func (u *userManager) AddUserRoles(ctx context.Context, domain accesstypes.Domai
 	}
 
 	for _, role := range roles {
-		if _, err := u.Enforcer().AddRoleForUser(user.Marshal(), role.Marshal(), domain.Marshal()); err != nil {
-			return errors.Wrapf(err, "casbin.SyncedEnforcer.AddRoleForUser(): role %q to %q", role, user)
+		if err := u.store.addUserRole(ctx, domain, user, role); err != nil {
+			return err
 		}
 	}
 
@@ -108,8 +90,8 @@ func (u *userManager) DeleteRoleUsers(ctx context.Context, domain accesstypes.Do
 	}
 
 	for _, user := range users {
-		if _, err := u.Enforcer().DeleteRoleForUser(user.Marshal(), role.Marshal(), domain.Marshal()); err != nil {
-			return errors.Wrapf(err, "casbin.SyncedEnforcer.AddRoleForUser(): role %q to %q", role.Marshal(), user)
+		if err := u.store.deleteUserRole(ctx, domain, user, role); err != nil {
+			return err
 		}
 	}
 
@@ -136,12 +118,12 @@ func (u *userManager) DeleteAllRolePermissions(ctx context.Context, domain acces
 // DeleteUserRoles removes multiple role assignments from a user within a domain.
 // The operation succeeds regardless of whether the roles were previously assigned to the user.
 func (u *userManager) DeleteUserRoles(ctx context.Context, domain accesstypes.Domain, user accesstypes.User, roles ...accesstypes.Role) error {
-	_, span := tracer.Start(ctx)
+	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
 	for _, role := range roles {
-		if _, err := u.Enforcer().DeleteRoleForUser(user.Marshal(), role.Marshal(), domain.Marshal()); err != nil {
-			return errors.Wrapf(err, "casbin.SyncedEnforcer.DeleteRoleForUser(): role %q to %q", role.Marshal(), user)
+		if err := u.store.deleteUserRole(ctx, domain, user, role); err != nil {
+			return err
 		}
 	}
 
@@ -212,60 +194,19 @@ func (u *userManager) users(ctx context.Context, domains []accesstypes.Domain) (
 	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
+	userIDs, err := u.store.users(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var users []*UserAccess
-	userMap := make(map[string]bool)
-	roles, err := u.Enforcer().GetAllRoles()
-	if err != nil {
-		return nil, errors.Wrap(err, "enforcer.GetAllRoles()")
-	}
-
-	subjects, err := u.Enforcer().GetAllSubjects()
-	if err != nil {
-		return nil, errors.Wrap(err, "enforcer.GetAllSubjects()")
-	}
-SUB:
-	// loop through the subjects (containing both roles and usernames)
-	// and if it is a a role, skip it, otherwise add user to the map
-	for _, user := range subjects {
-		for _, role := range roles {
-			if role == user || user == accesstypes.NoopUser {
-				continue SUB
-			}
-		}
-
-		accessUser, err := u.user(ctx, accesstypes.UnmarshalUser(user), domains)
+	for _, user := range userIDs {
+		accessUser, err := u.user(ctx, user, domains)
 		if err != nil {
 			return nil, err
 		}
 
 		users = append(users, accessUser)
-		userMap[user] = true
-	}
-	// now get the grouping policy and look for users in there
-	groupingPolicy, err := u.Enforcer().GetGroupingPolicy()
-	if err != nil {
-		return nil, errors.Wrap(err, "enforcer.GetGroupingPolicy()")
-	}
-GP:
-	for _, gp := range groupingPolicy {
-		user := gp[0]
-		if userMap[user] || user == accesstypes.NoopUser {
-			continue
-		}
-
-		for _, role := range roles {
-			if role == user {
-				continue GP
-			}
-		}
-
-		accessUser, err := u.user(ctx, accesstypes.UnmarshalUser(user), domains)
-		if err != nil {
-			return nil, err
-		}
-
-		users = append(users, accessUser)
-		userMap[user] = true
 	}
 
 	sort.Slice(users, func(i, j int) bool {
@@ -298,20 +239,16 @@ func (u *userManager) UserRoles(ctx context.Context, user accesstypes.User, doma
 }
 
 func (u *userManager) userRoles(ctx context.Context, user accesstypes.User, domains []accesstypes.Domain) (accesstypes.RoleCollection, error) {
-	_, span := tracer.Start(ctx)
+	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
 	userRoles := make(accesstypes.RoleCollection)
 	for _, domain := range domains {
-		strRoles, err := u.Enforcer().GetRolesForUser(user.Marshal(), domain.Marshal())
+		roles, err := u.store.userRoles(ctx, domain, user)
 		if err != nil {
-			return nil, errors.Wrapf(err, "casbin.SyncedEnforcer.GetRolesForUser(): user: %q", user)
+			return nil, err
 		}
 
-		roles := make([]accesstypes.Role, 0, len(strRoles))
-		for _, role := range strRoles {
-			roles = append(roles, accesstypes.UnmarshalRole(role))
-		}
 		userRoles[domain] = roles
 	}
 
@@ -341,24 +278,17 @@ func (u *userManager) UserPermissions(ctx context.Context, user accesstypes.User
 }
 
 func (u *userManager) userPermissions(ctx context.Context, user accesstypes.User, domains []accesstypes.Domain) (accesstypes.UserPermissionCollection, error) {
-	_, span := tracer.Start(ctx)
+	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
 	userPermissions := make(accesstypes.UserPermissionCollection)
 	for _, domain := range domains {
-		userPermissions[domain] = make(map[accesstypes.Resource][]accesstypes.Permission)
-
-		strPerms, err := u.Enforcer().GetImplicitPermissionsForUser(user.Marshal(), domain.Marshal())
+		permissions, err := u.store.userPermissions(ctx, domain, user)
 		if err != nil {
-			return nil, errors.Wrap(err, "enforcer.GetImplicitPermissionsForUser()")
+			return nil, err
 		}
 
-		for _, perm := range strPerms {
-			if slices.Contains(userPermissions[domain][accesstypes.UnmarshalResource(perm[2])], accesstypes.UnmarshalPermission(perm[3])) {
-				continue
-			}
-			userPermissions[domain][accesstypes.UnmarshalResource(perm[2])] = append(userPermissions[domain][accesstypes.UnmarshalResource(perm[2])], accesstypes.UnmarshalPermission(perm[3]))
-		}
+		userPermissions[domain] = permissions
 	}
 
 	return userPermissions, nil
@@ -382,8 +312,8 @@ func (u *userManager) AddRole(ctx context.Context, domain accesstypes.Domain, ro
 		return httpio.NewBadRequestMessage("role cannot be empty string")
 	}
 
-	if _, err := u.Enforcer().AddGroupingPolicy(accesstypes.NoopUser, role.Marshal(), domain.Marshal()); err != nil {
-		return errors.Wrap(err, "enforcer.AddGroupingPolicy()")
+	if err := u.store.addRole(ctx, domain, role); err != nil {
+		return err
 	}
 
 	return nil
@@ -399,27 +329,10 @@ func (u *userManager) Roles(ctx context.Context, domain accesstypes.Domain) ([]a
 		return nil, httpio.NewNotFoundMessagef("domain %q does not exist", string(domain))
 	}
 
-	// filter by domain
-	grouping, err := u.Enforcer().GetFilteredGroupingPolicy(2, domain.Marshal())
+	roles, err := u.store.roles(ctx, domain)
 	if err != nil {
-		return nil, errors.Wrap(err, "enforcer.GetFilteredGroupingPolicy()")
+		return nil, err
 	}
-
-	roleMap := map[accesstypes.Role]bool{}
-	for _, group := range grouping {
-		roleMap[accesstypes.UnmarshalRole(group[1])] = true
-	}
-
-	roles := make([]accesstypes.Role, 0, len(roleMap))
-
-	for role := range roleMap {
-		roles = append(roles, role)
-	}
-
-	// ensures the list is always returned in the same order as casbin doesn't handle this
-	sort.Slice(roles, func(i int, j int) bool {
-		return string(roles[i]) < string(roles[j])
-	})
 
 	return roles, nil
 }
@@ -434,9 +347,9 @@ func (u *userManager) DeleteRole(ctx context.Context, domain accesstypes.Domain,
 		return false, httpio.NewBadRequestMessagef("Users assigned to the role. You cannot delete a role that has users assigned")
 	}
 
-	deleted, err := u.Enforcer().DeleteRole(role.Marshal())
+	deleted, err := u.store.deleteRole(ctx, role)
 	if err != nil {
-		return false, errors.Wrap(err, "enforcer.DeleteRole()")
+		return false, err
 	}
 
 	return deleted, nil
@@ -455,8 +368,8 @@ func (u *userManager) AddRolePermissions(ctx context.Context, domain accesstypes
 			return httpio.NewBadRequestMessage("permission cannot be empty string")
 		}
 
-		if _, err := u.Enforcer().AddPolicy(role.Marshal(), domain.Marshal(), accesstypes.GlobalResource.Marshal(), permission.Marshal(), "allow"); err != nil {
-			return errors.Wrap(err, "enforcer.AddPolicy()")
+		if err := u.store.addGrant(ctx, domain, role, permission, accesstypes.GlobalResource); err != nil {
+			return err
 		}
 	}
 
@@ -476,8 +389,8 @@ func (u *userManager) AddRolePermissionResources(ctx context.Context, domain acc
 			return httpio.NewBadRequestMessage("resource cannot be empty string")
 		}
 
-		if _, err := u.Enforcer().AddPolicy(role.Marshal(), domain.Marshal(), resource.Marshal(), permission.Marshal(), "allow"); err != nil {
-			return errors.Wrap(err, "enforcer.AddPolicy()")
+		if err := u.store.addGrant(ctx, domain, role, permission, resource); err != nil {
+			return err
 		}
 	}
 
@@ -493,8 +406,8 @@ func (u *userManager) DeleteRolePermissions(ctx context.Context, domain accessty
 	}
 
 	for _, permission := range permissions {
-		if _, err := u.Enforcer().RemoveFilteredPolicy(0, role.Marshal(), domain.Marshal(), accesstypes.GlobalResource.Marshal(), permission.Marshal()); err != nil {
-			return errors.Wrapf(err, "enforcer.RemoveFilteredPolicy() role=%q, domain=%q", role, domain)
+		if err := u.store.removeGrant(ctx, domain, role, permission, accesstypes.GlobalResource); err != nil {
+			return err
 		}
 	}
 
@@ -512,8 +425,8 @@ func (u *userManager) DeleteRolePermissionResources(
 	}
 
 	for _, resource := range resources {
-		if _, err := u.Enforcer().RemoveFilteredPolicy(0, role.Marshal(), domain.Marshal(), resource.Marshal(), permission.Marshal()); err != nil {
-			return errors.Wrapf(err, "enforcer.RemoveFilteredPolicy() role=%q, domain=%q", role, domain)
+		if err := u.store.removeGrant(ctx, domain, role, permission, resource); err != nil {
+			return err
 		}
 	}
 
@@ -521,23 +434,15 @@ func (u *userManager) DeleteRolePermissionResources(
 }
 
 func (u *userManager) RoleUsers(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) ([]accesstypes.User, error) {
-	_, span := tracer.Start(ctx)
+	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
-	users, err := u.Enforcer().GetUsersForRole(role.Marshal(), domain.Marshal())
+	users, err := u.store.roleUsers(ctx, domain, role)
 	if err != nil {
-		return nil, errors.Wrap(err, "enforcer.GetUsersForRole()")
+		return nil, err
 	}
 
-	actualUsers := make([]accesstypes.User, 0, len(users))
-	for _, u := range users {
-		if u == accesstypes.NoopUser {
-			continue
-		}
-		actualUsers = append(actualUsers, accesstypes.UnmarshalUser(u))
-	}
-
-	return actualUsers, nil
+	return users, nil
 }
 
 func (u *userManager) RolePermissions(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) (accesstypes.RolePermissionCollection, error) {
@@ -548,26 +453,19 @@ func (u *userManager) RolePermissions(ctx context.Context, domain accesstypes.Do
 		return nil, httpio.NewNotFoundMessagef("role %s doesn't exist", role)
 	}
 
-	policies, err := u.Enforcer().GetFilteredPolicy(0, role.Marshal(), domain.Marshal())
+	permissions, err := u.store.roleGrants(ctx, domain, role)
 	if err != nil {
-		return nil, errors.Wrap(err, "enforcer.GetFilteredPolicy()")
-	}
-
-	permissions := make(accesstypes.RolePermissionCollection, len(policies))
-	for _, p := range policies {
-		permissions[accesstypes.UnmarshalPermission(p[3])] = append(permissions[accesstypes.UnmarshalPermission(p[3])], accesstypes.UnmarshalResource(p[2]))
+		return nil, err
 	}
 
 	return permissions, nil
 }
 
 func (u *userManager) RoleExists(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) bool {
-	_, span := tracer.Start(ctx)
+	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
-	roles := u.Enforcer().GetRolesForUserInDomain(accesstypes.NoopUser, domain.Marshal())
-
-	return slices.Contains(roles, role.Marshal())
+	return u.store.roleExists(ctx, domain, role)
 }
 
 func (u *userManager) Domains(ctx context.Context) ([]accesstypes.Domain, error) {
@@ -589,21 +487,16 @@ func (u *userManager) Domains(ctx context.Context) ([]accesstypes.Domain, error)
 }
 
 func (u *userManager) hasUsersAssigned(ctx context.Context, domain accesstypes.Domain, role accesstypes.Role) (bool, error) {
-	_, span := tracer.Start(ctx)
+	ctx, span := tracer.Start(ctx)
 	defer span.End()
 
-	users, err := u.Enforcer().GetUsersForRole(role.Marshal(), domain.Marshal())
+	// roleUsers excludes the internal noop sentinel, so any user counts.
+	users, err := u.store.roleUsers(ctx, domain, role)
 	if err != nil {
-		return false, errors.Wrap(err, "enforcer.GetUsersForRole()")
+		return false, errors.Wrap(err, "roleUsers()")
 	}
 
-	// We aren't checking the single user to be someone else as it should always be noop if length is 1.
-	// Do we need to throw an error if it is someone other than noop?
-	if len(users) <= 1 {
-		return false, nil
-	}
-
-	return true, nil
+	return len(users) > 0, nil
 }
 
 // DomainExists checks if the domain exists in the application.

--- a/usermanagement_test.go
+++ b/usermanagement_test.go
@@ -125,9 +125,9 @@ func Test_userManager_User_Add_Delete(t *testing.T) {
 			}
 			c := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 			got, err := c.User(tt.args.ctx, tt.args.username)
 			if err != nil {
@@ -258,9 +258,9 @@ func Test_userManager_Users(t *testing.T) {
 
 			c := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			got, err := c.Users(tt.args.ctx)
@@ -324,9 +324,9 @@ func Test_userManager_RolePermissions(t *testing.T) {
 			ctx := context.Background()
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			got, err := c.RolePermissions(ctx, tt.args.domain, tt.args.role)
@@ -387,9 +387,9 @@ func Test_userManager_RoleUsers(t *testing.T) {
 			}
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			got, err := c.RoleUsers(ctx, tt.args.domain, tt.args.role)
@@ -448,9 +448,9 @@ func Test_userManager_DeleteRoleUsers(t *testing.T) {
 			}
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := c.DeleteRoleUsers(ctx, tt.args.domain, tt.args.role, tt.args.users...); (err != nil) != tt.wantErr {
@@ -552,9 +552,9 @@ func Test_userManager_AddRole(t *testing.T) {
 
 			c := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := c.AddRole(tt.args.ctx, tt.args.domain, tt.args.role); (err != nil) != tt.wantErr {
@@ -648,9 +648,9 @@ func Test_userManager_AddUserRoles(t *testing.T) {
 
 			u := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := u.AddUserRoles(ctx, tt.args.domain, tt.args.user, tt.args.roles...); (err != nil) != tt.wantErr {
@@ -756,9 +756,9 @@ func Test_userManager_Roles(t *testing.T) {
 
 			c := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			got, err := c.Roles(tt.args.ctx, tt.args.domain)
@@ -900,9 +900,9 @@ func Test_userManager_DeleteRole(t *testing.T) {
 			}
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			got, err := c.DeleteRole(ctx, tt.args.domain, tt.args.role)
@@ -980,9 +980,9 @@ func Test_userManager_DeleteRolePermissions(t *testing.T) {
 			}
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := c.DeleteRolePermissions(ctx, tt.args.domain, tt.args.role, tt.args.permissions...); err != nil {
@@ -1057,9 +1057,9 @@ func Test_userManager_DeleteAllRolePermissions(t *testing.T) {
 			}
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := c.DeleteAllRolePermissions(ctx, tt.args.domain, tt.args.role); err != nil {
@@ -1148,9 +1148,9 @@ func Test_userManager_AddRolePermissions(t *testing.T) {
 			}
 
 			c := &userManager{
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := c.AddRolePermissions(ctx, tt.args.domain, tt.args.role, tt.args.permissions...); err != nil {
@@ -1314,9 +1314,9 @@ func Test_userManager_AddRoleUsers(t *testing.T) {
 
 			u := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := u.AddRoleUsers(tt.args.ctx, tt.args.domain, tt.args.role, tt.args.users...); (err != nil) != tt.wantErr {
@@ -1393,9 +1393,9 @@ func Test_userManager_AddRolePermissionResources(t *testing.T) {
 
 			u := &userManager{
 				domains: domains,
-				Enforcer: func() casbin.IEnforcer {
+				store: &casbinEngine{Enforcer: func() casbin.IEnforcer {
 					return enforcer
-				},
+				}},
 			}
 
 			if err := u.AddRolePermissionResources(tt.args.ctx, tt.args.domain, tt.args.role, tt.args.permission, tt.args.resources...); (err != nil) != tt.wantErr {


### PR DESCRIPTION
Define unexported evaluator (batch checkUser/checkRole) and policyStore
(membership, roles, grants) interfaces as the seam a future permission
engine will implement. Wrap the existing casbin path as the first
implementation (casbinEngine), moving all casbin-specific concerns —
enforcer lifecycle, Marshal prefixes, and the noop sentinel user —
behind the seam. No public API or behavior change.

Also adds seam-level check tests covering the RequireAll /
RequireResources evaluation paths.